### PR TITLE
Add pesel test

### DIFF
--- a/Insurance_company/accounts/models.py
+++ b/Insurance_company/accounts/models.py
@@ -14,19 +14,17 @@ class Customer(models.Model):
     privacy_policy_accepted = models.BooleanField(default=False)
     marketing_agreement = models.BooleanField(default=False)
 
-def __str__(self):
-    return f"Customer profile of {self.user.username}"
+    def __str__(self):
+        return f"Customer profile of {self.user.username}"
 
-
-def clean(self):
-    super().clean()
-    # Checking the correctness of the PESEL checksum
-    if self.pesel:
-        weights = [1, 3, 7, 9, 1, 3, 7, 9, 1, 3]
-        checksum = sum(int(self.pesel[i]) * weights[i] for i in range(10))
-        control_sum = checksum % 10
-        if control_sum != 0:
-            control_sum = 10 - control_sum
-        if control_sum != int(self.pesel[10]):
-            raise ValidationError('Invalid PESEL checksum')
-
+    def clean(self):
+        super().clean()
+        # Checking the correctness of the PESEL checksum
+        if self.pesel:
+            weights = [1, 3, 7, 9, 1, 3, 7, 9, 1, 3]
+            checksum = sum(int(self.pesel[i]) * weights[i] for i in range(10))
+            control_sum = checksum % 10
+            if control_sum != 0:
+                control_sum = 10 - control_sum
+            if control_sum != int(self.pesel[10]):
+                raise ValidationError('Invalid PESEL checksum')

--- a/Insurance_company/accounts/tests.py
+++ b/Insurance_company/accounts/tests.py
@@ -4,22 +4,19 @@ from django.core.exceptions import ValidationError
 from accounts.models import Customer
 
 class CustomerPeselTestCase(TestCase):
-
-    def test_pesel_validation(self):
+    # Ensure that valid PESEL passes validation
+    def test_valid_pesel(self):
         valid_pesel = '44051401458'
+        self.assertIsNone(Customer(pesel=valid_pesel).clean())
+
+    # Ensure that invalid PESEL with valid checksum raises ValidationError
+    def test_invalid_pesel_with_valid_checksum(self):
         invalid_pesel_with_valid_checksum = '22222222222'
+        with self.assertRaises(ValidationError):
+            Customer(pesel=invalid_pesel_with_valid_checksum).clean()
+
+    # Ensure that PESEL with invalid checksum raises ValidationError
+    def test_invalid_pesel_with_invalid_checksum(self):
         invalid_pesel_with_invalid_checksum = '12345678900'
-
-        # Ensure that valid PESEL passes validation
-        with self.subTest(pesel=valid_pesel):
-            self.assertIsNone(Customer(pesel=valid_pesel).clean())
-
-        # Ensure that invalid PESEL with valid checksum raises ValidationError
-        with self.subTest(pesel=invalid_pesel_with_valid_checksum):
-            with self.assertRaises(ValidationError):
-                Customer(pesel=invalid_pesel_with_valid_checksum).clean()
-
-        # Ensure that PESEL with invalid checksum raises ValidationError
-        with self.subTest(pesel=invalid_pesel_with_invalid_checksum):
-            with self.assertRaises(ValidationError):
-                Customer(pesel=invalid_pesel_with_invalid_checksum).clean()
+        with self.assertRaises(ValidationError):
+            Customer(pesel=invalid_pesel_with_invalid_checksum).clean()

--- a/Insurance_company/accounts/tests.py
+++ b/Insurance_company/accounts/tests.py
@@ -14,10 +14,10 @@ class CustomerPeselTestCase(TestCase):
         with self.subTest(pesel=valid_pesel):
             self.assertIsNone(Customer(pesel=valid_pesel).clean())
 
-        # Ensure that invalid PESEL with valid checksum passes validation
-        ''' THAT SHOULD NOT HAPPEN - WE NEED MORE SAFEGUARDS '''
+        # Ensure that invalid PESEL with valid checksum raises ValidationError
         with self.subTest(pesel=invalid_pesel_with_valid_checksum):
-            self.assertIsNone(Customer(pesel=invalid_pesel_with_valid_checksum).clean())
+            with self.assertRaises(ValidationError):
+                Customer(pesel=invalid_pesel_with_valid_checksum).clean()
 
         # Ensure that PESEL with invalid checksum raises ValidationError
         with self.subTest(pesel=invalid_pesel_with_invalid_checksum):

--- a/Insurance_company/accounts/tests.py
+++ b/Insurance_company/accounts/tests.py
@@ -1,3 +1,25 @@
 from django.test import TestCase
+from django.core.exceptions import ValidationError
 
-# Create your tests here.
+from accounts.models import Customer
+
+class CustomerPeselTestCase(TestCase):
+
+    def test_pesel_validation(self):
+        valid_pesel = '44051401458'
+        invalid_pesel_with_valid_checksum = '22222222222'
+        invalid_pesel_with_invalid_checksum = '12345678900'
+
+        # Ensure that valid PESEL passes validation
+        with self.subTest(pesel=valid_pesel):
+            self.assertIsNone(Customer(pesel=valid_pesel).clean())
+
+        # Ensure that invalid PESEL with valid checksum passes validation
+        ''' THAT SHOULD NOT HAPPEN - WE NEED MORE SAFEGUARDS '''
+        with self.subTest(pesel=invalid_pesel_with_valid_checksum):
+            self.assertIsNone(Customer(pesel=invalid_pesel_with_valid_checksum).clean())
+
+        # Ensure that PESEL with invalid checksum raises ValidationError
+        with self.subTest(pesel=invalid_pesel_with_invalid_checksum):
+            with self.assertRaises(ValidationError):
+                Customer(pesel=invalid_pesel_with_invalid_checksum).clean()


### PR DESCRIPTION
Dodano testy numerów PESEL dla:
- numeru poprawnego
- numeru błędnego, ale zgodnego z sumą kontrolną
- numeru błędnego niezgodnego z sumą kontrolną