### PR TITLE
Added password change

### DIFF
--- a/Insurance_company/accounts/models.py
+++ b/Insurance_company/accounts/models.py
@@ -9,7 +9,7 @@ User = settings.AUTH_USER_MODEL
 class Customer(models.Model):
 
     user = models.OneToOneField(User, on_delete=models.CASCADE)
-    pesel = models.CharField(max_length=11, validators=[validate_pesel])
+    pesel = models.CharField(max_length=11, validators=[validate_pesel, validate_pesel_unique])
     address = models.CharField(max_length=255)
     phone_number = models.CharField(max_length=15, blank=True)
     privacy_policy_accepted = models.BooleanField(default=False)
@@ -17,4 +17,3 @@ class Customer(models.Model):
 
     def __str__(self):
         return f"Customer profile of {self.user.username}"
-

--- a/Insurance_company/accounts/templates/accounts/customer_detail.html
+++ b/Insurance_company/accounts/templates/accounts/customer_detail.html
@@ -52,6 +52,12 @@ Dane użytkownika
 
 <div style="text-align:center;">
     <button class="btn btn-info" style="margin-top: 2rem;">
+        <a href="{% url 'password_change' request.user.customer.pk %}" style="text-decoration:none;color:white;">Zmień swoje hasło</a>
+    </button>
+</div>
+
+<div style="text-align:center;">
+    <button class="btn btn-info" style="margin-top: 2rem;">
         <a href="{% url 'policy_list' %}" style="text-decoration:none;color:white;">Sprawdź listę zawartych polis</a>
     </button>
 </div>

--- a/Insurance_company/accounts/templates/accounts/login.html
+++ b/Insurance_company/accounts/templates/accounts/login.html
@@ -7,6 +7,15 @@
 {% block content %}
 <h3 style="text-align:center;margin-top:4rem;" class="text-secondary">Logowanie</h3>
 <div style="width:40%;margin-left:auto;margin-right:auto;margin-top:3rem;">
+
+        {% if messages %}
+        <ul class="messages">
+            {% for message in messages %}
+                <p style="text-align:center;color:red;">{{ message }}</p>
+            {% endfor %}
+        </ul>
+    {% endif %}
+
 <form action="{% url 'login' %}" method="post">
     {% csrf_token %}
     {{ form|crispy }}

--- a/Insurance_company/accounts/templates/accounts/password_change.html
+++ b/Insurance_company/accounts/templates/accounts/password_change.html
@@ -1,0 +1,39 @@
+{% extends "base.html" %}
+
+{% block title %}
+Zmiana hasła użytkownika
+{% endblock title %}
+
+{% block content %}
+<h3 style="text-align:center;margin-top:8rem;color:red;">Ze względów bezpieczeństwa po zmianie hasła zostaniesz przekierowany/a na stronę logowania, gdzie będziesz musiał/a zalogować się nowym hasłem.</h3>
+<h3 style="text-align:center;margin-top:3rem;">Wprowadź nowe hasło:</h3>
+<div style="width:60%;margin-top:3rem;margin-left:auto;margin-right:auto;">
+    <form method="post">
+        {% csrf_token %}
+
+        {{ form.as_p }}
+
+        <div style="text-align:center;">
+        <button type="submit" class="btn btn-info" style="margin-top: 2rem; text-decoration:none;color:white;">Zmień hasło</button>
+        </div>
+    </form>
+</div>
+
+<div style="text-align:center;">
+    <button class="btn btn-info" style="margin-top: 2rem;">
+        <a href="{% url 'customer_detail' customer.pk %}" style="text-decoration:none;color:white;">Wróć do swoich danych</a>
+    </button>
+</div>
+
+<div style="text-align:center;">
+    <button class="btn btn-info" style="margin-top: 2rem;">
+        <a href="{% url 'policy_list' %}" style="text-decoration:none;color:white;">Sprawdź listę zawartych polis</a>
+    </button>
+</div>
+
+<div style="text-align:center;">
+    <button class="btn btn-info" style="margin-top: 2rem;">
+        <a href="{% url 'main_page' %}" style="text-decoration:none;color:white;">Wróć do strony głównej</a>
+    </button>
+</div>
+{% endblock content %}

--- a/Insurance_company/accounts/urls.py
+++ b/Insurance_company/accounts/urls.py
@@ -1,7 +1,7 @@
 from django.urls import path
 from django.contrib.auth.views import LoginView, LogoutView
 
-from .views import LogoutConfirmView, RegisterView, CustomerDetailView, CustomerUpdateView
+from .views import LogoutConfirmView, RegisterView, CustomerDetailView, CustomerUpdateView, CustomerPasswordChangeView
 
 urlpatterns = [
     path("login/", LoginView.as_view(template_name="accounts/login.html"), name="login"),
@@ -10,4 +10,5 @@ urlpatterns = [
     path("register/", RegisterView.as_view(), name="register"),
     path("customer_detail/<int:pk>", CustomerDetailView.as_view(), name="customer_detail"),
     path("customer_detail/<int:pk>/update/", CustomerUpdateView.as_view(), name="customer_update"),
+    path("customer_detail/<int:pk>/password_change", CustomerPasswordChangeView.as_view(), name="password_change"),
 ]

--- a/Insurance_company/accounts/views.py
+++ b/Insurance_company/accounts/views.py
@@ -1,6 +1,7 @@
 from django.shortcuts import render, redirect, get_object_or_404
 from django.views.generic import View, DetailView
 from django.contrib import messages
+from django.contrib.auth.forms import SetPasswordForm
 
 from accounts.models import Customer
 from accounts.forms import CustomerForm, CustomUserForm
@@ -48,6 +49,7 @@ class RegisterView(View):
 
         return customer_profile
 
+
 class CustomerDetailView(View):
     def get(self, request, pk):
         customer = get_object_or_404(Customer, pk=pk)
@@ -91,3 +93,30 @@ class CustomerUpdateView(View):
 
         context = {'form': form, 'customer': customer}
         return render(request, 'accounts/customer_update.html', context)
+
+
+class CustomerPasswordChangeView(View):
+    def get(self, request, pk):
+        customer = get_object_or_404(Customer, pk=pk)
+
+        if not request.user.is_authenticated:
+            return render(request, "404.html")
+        elif request.user.customer != customer:
+            return render(request, "404.html")
+
+        form = SetPasswordForm(user=request.user)
+        context = {'form': form, 'customer': customer}
+
+        return render(request, 'accounts/password_change.html', context)
+
+    def post(self, request, pk):
+        customer = get_object_or_404(Customer, pk=pk)
+        form = SetPasswordForm(user=request.user, data=request.POST)
+
+        if form.is_valid():
+            form.save()
+            messages.success(request, f"Pomyślnie wprowadzono nowe hasło.")
+            return redirect('login')
+
+        context = {'form': form, 'customer': customer}
+        return render(request, 'accounts/password_change.html', context)


### PR DESCRIPTION
Dodałem opcję zmiany hasła (nowy widok i nowa templatka), z odpowiednimi zabezpieczeniami.
Zmiana wylogowuje naszego klienta i odsyła na stronę logowania. Moglibyśmy logować klienta automatycznie, ale podobno bezpieczniej jest robić to w ten sposób. Klient jest o tym uprzedzany, dodałem też message do strony logowania dla lepszej czytelności.
Dodałem testy dla zmiany hasła.
Przywróciłem walidator unikalności PESEL w modelu Customera - został usunięty, gdy rozważaliśmy umożliwnienie klientowi zmianę numeru PESEL. Skoro zrezygnowaliśmy z tej opcji, to walidator wraca na swoje miejsce.